### PR TITLE
Allow Spacy < 3.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "spacy >= 3.4.1, < 3.6",
+    "spacy >= 3.4.1, < 4.0",
     "PyRuSH >= 1.0.8",
     "pysbd == 0.3.4",
     "jsonschema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "spacy >= 3.4.1, < 4.0",
+    "spacy >= 3.4.1, < 3.7.0",
     "PyRuSH >= 1.0.8",
     "pysbd == 0.3.4",
     "jsonschema",


### PR DESCRIPTION
Required for newer SciSpacy compatibility. This was previously disallowed upstream in order to prevent development versions of spacy from being included. 